### PR TITLE
Update: Packages to scan need to be specified

### DIFF
--- a/springrecipes-master/Ch10/Recipe_10_7_vi/src/main/java/com/apress/springrecipes/course/config/CourseConfiguration.java
+++ b/springrecipes-master/Ch10/Recipe_10_7_vi/src/main/java/com/apress/springrecipes/course/config/CourseConfiguration.java
@@ -28,6 +28,7 @@ public class CourseConfiguration {
     public LocalContainerEntityManagerFactoryBean entityManagerFactory() {
         LocalContainerEntityManagerFactoryBean emf = new LocalContainerEntityManagerFactoryBean();
         emf.setDataSource(dataSource());
+	emf.setPackagesToScan("com.apress.springrecipes.course");
         emf.setJpaVendorAdapter(jpaVendorAdapter());
         return emf;
     }


### PR DESCRIPTION
Packages to scan need to be specified in order to completely remove persistence.xml.